### PR TITLE
fix: typo when import & no need for await

### DIFF
--- a/backup_manager.py
+++ b/backup_manager.py
@@ -15,7 +15,7 @@ async def run_backup(bot: discord.ext.commands.bot.Bot, guild: discord.guild.Gui
     backup_path = os.path.join(backup_folder, f"{guild.name}_{timestamp}")
     os.makedirs(backup_path, exist_ok=True)
 
-    await export_structure(guild, backup_path)
+    export_structure(guild, backup_path)
 
     for channel in guild.text_channels:
         await export_channel_messages(channel, backup_path)

--- a/bot.py
+++ b/bot.py
@@ -2,9 +2,10 @@ import discord
 from discord.ext import commands
 import asyncio
 import json
+import threading
 
 from backup_manager import run_backup
-from scheduler import schedule_backups
+from utils.scheduler import schedule_backups
 
 # -----------------------------------------------------
 # 載入 Token 與設定

--- a/config.json
+++ b/config.json
@@ -2,7 +2,7 @@
    "bot_token": "YOUR_DISCORD_BOT_TOKEN",
    "guild_id": "123456789012345678",
    "output_format": ["json", "html", "txt"],
-   "backup_folder": "./backups"
-   "SCHEDULE": false
+   "backup_folder": "./backups",
+   "SCHEDULE": false,
    "download_attachments": false
  }


### PR DESCRIPTION
1. 把await移除。
2. bot.py當中有用到threading，我把它補上
3. 把bot.py當中import scheduler改成import utils.scheduler
4. 把json當中的','補上